### PR TITLE
Add WooValidate email verification plugin skeleton

### DIFF
--- a/wp-content/plugins/woo-validate/includes/class-woo-validate-checkout.php
+++ b/wp-content/plugins/woo-validate/includes/class-woo-validate-checkout.php
@@ -1,0 +1,144 @@
+<?php
+/**
+ * WooValidate checkout integration.
+ *
+ * @package WooValidate
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+if ( ! class_exists( 'WooValidate_Checkout' ) ) {
+    /**
+     * Handles WooCommerce checkout validation hooks.
+     */
+    class WooValidate_Checkout {
+
+        /**
+         * Validator service instance.
+         *
+         * @var WooValidate_Email_Validator
+         */
+        protected $validator;
+
+        /**
+         * Constructor.
+         */
+        public function __construct() {
+            $this->validator = new WooValidate_Email_Validator();
+
+            add_action( 'woocommerce_checkout_process', array( $this, 'validate_checkout_email' ) );
+            add_action( 'woocommerce_after_checkout_validation', array( $this, 'suggest_checkout_email' ), 10, 2 );
+            add_action( 'woocommerce_register_post', array( $this, 'validate_registration_email' ), 10, 3 );
+            add_filter( 'woocommerce_email_customer_details_fields', array( $this, 'flag_risky_email_in_order' ), 10, 3 );
+        }
+
+        /**
+         * Validate checkout email before order submission.
+         */
+        public function validate_checkout_email() {
+            if ( empty( $_POST['billing_email'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification
+                return;
+            }
+
+            $email   = sanitize_email( wp_unslash( $_POST['billing_email'] ) ); // phpcs:ignore WordPress.Security.NonceVerification
+            $result  = $this->validator->validate_email( $email );
+            $context = __( 'billing', 'woo-validate' );
+
+            if ( ! $result['valid'] ) {
+                $message = sprintf(
+                    /* translators: %1$s is the reason message. */
+                    __( 'There is an issue with the %s email address: %s', 'woo-validate' ),
+                    $context,
+                    $result['reason']
+                );
+
+                if ( ! empty( $result['suggestion'] ) ) {
+                    $message .= ' ' . sprintf(
+                        /* translators: %s is the suggested email address. */
+                        __( 'Did you mean %s?', 'woo-validate' ),
+                        '<strong>' . esc_html( $result['suggestion'] ) . '</strong>'
+                    );
+                }
+
+                wc_add_notice( wp_kses_post( $message ), 'error' );
+            }
+        }
+
+        /**
+         * Add suggestion notice after validation if available.
+         *
+         * @param array    $data   Posted data.
+         * @param WP_Error $errors Validation errors.
+         */
+        public function suggest_checkout_email( $data, $errors ) {
+            if ( ! empty( $errors->get_error_codes() ) ) {
+                return;
+            }
+
+            $email  = isset( $data['billing_email'] ) ? sanitize_email( $data['billing_email'] ) : '';
+            $result = $this->validator->validate_email( $email );
+
+            if ( $result['valid'] || empty( $result['suggestion'] ) ) {
+                return;
+            }
+
+            wc_add_notice(
+                sprintf(
+                    /* translators: %s is the suggested email address. */
+                    __( 'We had trouble with your email address. Try %s if it was a typo.', 'woo-validate' ),
+                    '<strong>' . esc_html( $result['suggestion'] ) . '</strong>'
+                ),
+                'notice'
+            );
+        }
+
+        /**
+         * Validate registration email during account creation.
+         *
+         * @param string   $username Submitted username.
+         * @param string   $email    Submitted email.
+         * @param WP_Error $errors   Error object.
+         */
+        public function validate_registration_email( $username, $email, $errors ) {
+            unset( $username );
+
+            $result = $this->validator->validate_email( $email );
+
+            if ( ! $result['valid'] ) {
+                $errors->add( 'woo_validate_email', $result['reason'] );
+            }
+        }
+
+        /**
+         * Add customer note when risky email is detected in orders.
+         *
+         * @param array    $fields        Email fields.
+         * @param bool     $sent_to_admin Whether sent to admin.
+         * @param WC_Order $order         Order object.
+         *
+         * @return array
+         */
+        public function flag_risky_email_in_order( $fields, $sent_to_admin, $order ) {
+            unset( $sent_to_admin );
+
+            $email = $order instanceof WC_Order ? $order->get_billing_email() : '';
+
+            if ( empty( $email ) ) {
+                return $fields;
+            }
+
+            if ( $this->validator->validate_email( $email )['valid'] ) {
+                return $fields;
+            }
+
+            $fields['woo_validate_warning'] = array(
+                'label' => __( 'Email validation', 'woo-validate' ),
+                'value' => __( 'This order used an email address that failed validation checks.', 'woo-validate' ),
+            );
+
+            return $fields;
+        }
+    }
+}

--- a/wp-content/plugins/woo-validate/includes/class-woo-validate-validator.php
+++ b/wp-content/plugins/woo-validate/includes/class-woo-validate-validator.php
@@ -1,0 +1,200 @@
+<?php
+/**
+ * WooValidate email validator.
+ *
+ * @package WooValidate
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+if ( ! class_exists( 'WooValidate_Email_Validator' ) ) {
+    /**
+     * Email validation service.
+     */
+    class WooValidate_Email_Validator {
+
+        /**
+         * Constructor.
+         */
+        public function __construct() {
+            $this->disposable_domains = apply_filters( 'woo_validate_disposable_domains', $this->disposable_domains );
+            $this->risky_addresses    = apply_filters( 'woo_validate_risky_addresses', $this->risky_addresses );
+            $this->common_domains     = apply_filters( 'woo_validate_common_domains', $this->common_domains );
+        }
+
+        /**
+         * Disposable email domains.
+         *
+         * @var array<string>
+         */
+        protected $disposable_domains = array(
+            '10minutemail.com',
+            'guerrillamail.com',
+            'mailinator.com',
+            'tempmail.com',
+            'yopmail.com',
+        );
+
+        /**
+         * Known risky email addresses (commonly abused).
+         *
+         * @var array<string>
+         */
+        protected $risky_addresses = array(
+            'test@example.com',
+            'fake@example.com',
+            'noreply@example.com',
+        );
+
+        /**
+         * Common domains for suggestion comparison.
+         *
+         * @var array<string>
+         */
+        protected $common_domains = array(
+            'gmail.com',
+            'yahoo.com',
+            'outlook.com',
+            'hotmail.com',
+            'icloud.com',
+            'aol.com',
+        );
+
+        /**
+         * Validate email address.
+         *
+         * @param string $email Email address.
+         *
+         * @return array{
+         *     valid: bool,
+         *     reason: string|null,
+         *     suggestion: string|null
+         * }
+         */
+        public function validate_email( $email ) {
+            $email = trim( $email );
+
+            if ( '' === $email ) {
+                return array(
+                    'valid'      => false,
+                    'reason'     => __( 'Email address is required.', 'woo-validate' ),
+                    'suggestion' => null,
+                );
+            }
+
+            if ( ! filter_var( $email, FILTER_VALIDATE_EMAIL ) ) {
+                return array(
+                    'valid'      => false,
+                    'reason'     => __( 'Please enter a valid email address.', 'woo-validate' ),
+                    'suggestion' => $this->suggest_email( $email ),
+                );
+            }
+
+            $domain = strtolower( substr( strrchr( $email, '@' ), 1 ) );
+
+            if ( ! $this->has_valid_dns_records( $domain ) ) {
+                return array(
+                    'valid'      => false,
+                    'reason'     => __( 'The email domain cannot receive messages. Please use a different email address.', 'woo-validate' ),
+                    'suggestion' => $this->suggest_email( $email ),
+                );
+            }
+
+            if ( $this->is_disposable_domain( $domain ) ) {
+                return array(
+                    'valid'      => false,
+                    'reason'     => __( 'Disposable email addresses are not allowed. Please provide a permanent address.', 'woo-validate' ),
+                    'suggestion' => null,
+                );
+            }
+
+            if ( $this->is_risky_address( $email ) ) {
+                return array(
+                    'valid'      => false,
+                    'reason'     => __( 'This email address is flagged as high risk. Please use another email.', 'woo-validate' ),
+                    'suggestion' => null,
+                );
+            }
+
+            return array(
+                'valid'      => true,
+                'reason'     => null,
+                'suggestion' => null,
+            );
+        }
+
+        /**
+         * Determine if domain has valid DNS.
+         *
+         * @param string $domain Domain portion of email.
+         * @return bool
+         */
+        protected function has_valid_dns_records( $domain ) {
+            if ( '' === $domain ) {
+                return false;
+            }
+
+            if ( function_exists( 'checkdnsrr' ) && ( checkdnsrr( $domain, 'MX' ) || checkdnsrr( $domain, 'A' ) ) ) {
+                return true;
+            }
+
+            $records = dns_get_record( $domain, DNS_MX | DNS_A );
+
+            return ! empty( $records );
+        }
+
+        /**
+         * Check if email domain is disposable.
+         *
+         * @param string $domain Domain portion of email.
+         * @return bool
+         */
+        protected function is_disposable_domain( $domain ) {
+            return in_array( $domain, $this->disposable_domains, true );
+        }
+
+        /**
+         * Check if email is risky.
+         *
+         * @param string $email Email address.
+         * @return bool
+         */
+        protected function is_risky_address( $email ) {
+            return in_array( strtolower( $email ), $this->risky_addresses, true );
+        }
+
+        /**
+         * Suggest email correction.
+         *
+         * @param string $email Email address.
+         * @return string|null
+         */
+        protected function suggest_email( $email ) {
+            list( $local, $domain ) = array_pad( explode( '@', strtolower( $email ) ), 2, '' );
+
+            if ( '' === $domain ) {
+                return null;
+            }
+
+            $closest_domain = null;
+            $shortest       = -1;
+
+            foreach ( $this->common_domains as $common_domain ) {
+                $distance = levenshtein( $domain, $common_domain );
+
+                if ( $distance < 3 && ( $distance < $shortest || $shortest < 0 ) ) {
+                    $shortest       = $distance;
+                    $closest_domain = $common_domain;
+                }
+            }
+
+            if ( null !== $closest_domain ) {
+                return $local . '@' . $closest_domain;
+            }
+
+            return null;
+        }
+    }
+}

--- a/wp-content/plugins/woo-validate/readme.txt
+++ b/wp-content/plugins/woo-validate/readme.txt
@@ -1,0 +1,42 @@
+=== WooValidate Email Verification ===
+Contributors: woovalidate
+Tags: woocommerce, email, validation, checkout
+Requires at least: 5.9
+Tested up to: 6.5
+Stable tag: 1.0.0
+License: GPLv2 or later
+License URI: http://www.gnu.org/licenses/gpl-2.0.html
+
+Enforce high quality customer email addresses during WooCommerce checkout.
+
+== Description ==
+
+WooValidate prevents orders from using invalid, disposable, and high-risk email addresses. The plugin performs:
+
+* Syntax validation to block malformed addresses.
+* Domain verification using DNS lookups to ensure the address can receive mail.
+* Disposable domain detection to prevent throwaway inboxes.
+* Reputation screening against a curated list of risky addresses.
+
+When a problem is detected, customers see a clear message during checkout and account creation along with suggested corrections for common typos. This ensures orders are placed using a valid inbox before payment is processed.
+
+== Installation ==
+
+1. Upload the plugin files to `/wp-content/plugins/woo-validate` or install the plugin through the WordPress plugins screen directly.
+2. Activate the plugin through the 'Plugins' screen in WordPress.
+3. Make sure WooCommerce is active. WooValidate will immediately begin validating checkout and registration email fields.
+
+== Frequently Asked Questions ==
+
+= Does this plugin connect to external services? =
+
+No. WooValidate performs validation locally using PHP and DNS lookups. Disposable and risky email lists can be customized by developers via filters.
+
+= Can I customize the lists of risky or disposable addresses? =
+
+Yes. Developers can hook into the `woo_validate_disposable_domains` and `woo_validate_risky_addresses` filters to change the behavior.
+
+== Changelog ==
+
+= 1.0.0 =
+* Initial release.

--- a/wp-content/plugins/woo-validate/woo-validate.php
+++ b/wp-content/plugins/woo-validate/woo-validate.php
@@ -1,0 +1,119 @@
+<?php
+/**
+ * Plugin Name: WooValidate Email Verification
+ * Plugin URI:  https://example.com/woovalidate
+ * Description: Advanced email validation for WooCommerce checkout and account flows. Performs syntax, domain, and reputation checks before orders are placed.
+ * Version:     1.0.0
+ * Author:      WooValidate
+ * Author URI:  https://example.com
+ * License:     GPL-2.0-or-later
+ * License URI: http://www.gnu.org/licenses/gpl-2.0.txt
+ * Text Domain: woo-validate
+ * Domain Path: /languages
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+if ( ! class_exists( 'WooValidate' ) ) {
+    /**
+     * Main plugin class.
+     */
+    class WooValidate {
+
+        /**
+         * Instance of the plugin.
+         *
+         * @var WooValidate|null
+         */
+        protected static $instance = null;
+
+        /**
+         * Plugin version.
+         */
+        const VERSION = '1.0.0';
+
+        /**
+         * Plugin slug.
+         */
+        const SLUG = 'woo-validate';
+
+        /**
+         * Create or retrieve instance.
+         *
+         * @return WooValidate
+         */
+        public static function get_instance() {
+            if ( null === self::$instance ) {
+                self::$instance = new self();
+            }
+
+            return self::$instance;
+        }
+
+        /**
+         * WooValidate constructor.
+         */
+        private function __construct() {
+            $this->define_constants();
+            $this->includes();
+            $this->hooks();
+        }
+
+        /**
+         * Define plugin constants.
+         */
+        protected function define_constants() {
+            if ( ! defined( 'WOO_VALIDATE_VERSION' ) ) {
+                define( 'WOO_VALIDATE_VERSION', self::VERSION );
+            }
+
+            if ( ! defined( 'WOO_VALIDATE_PATH' ) ) {
+                define( 'WOO_VALIDATE_PATH', plugin_dir_path( __FILE__ ) );
+            }
+
+            if ( ! defined( 'WOO_VALIDATE_URL' ) ) {
+                define( 'WOO_VALIDATE_URL', plugin_dir_url( __FILE__ ) );
+            }
+        }
+
+        /**
+         * Include required files.
+         */
+        protected function includes() {
+            require_once WOO_VALIDATE_PATH . 'includes/class-woo-validate-validator.php';
+            require_once WOO_VALIDATE_PATH . 'includes/class-woo-validate-checkout.php';
+        }
+
+        /**
+         * Register hooks.
+         */
+        protected function hooks() {
+            add_action( 'plugins_loaded', array( $this, 'load_textdomain' ) );
+            add_action( 'woocommerce_init', array( $this, 'boot_checkout_integration' ) );
+        }
+
+        /**
+         * Load plugin textdomain.
+         */
+        public function load_textdomain() {
+            load_plugin_textdomain( 'woo-validate', false, dirname( plugin_basename( __FILE__ ) ) . '/languages' );
+        }
+
+        /**
+         * Boot WooCommerce integrations after WooCommerce is loaded.
+         */
+        public function boot_checkout_integration() {
+            if ( ! class_exists( 'WooCommerce' ) ) {
+                return;
+            }
+
+            if ( class_exists( 'WooValidate_Checkout' ) ) {
+                new WooValidate_Checkout();
+            }
+        }
+    }
+
+    WooValidate::get_instance();
+}


### PR DESCRIPTION
## Summary
- add the WooValidate plugin bootstrap with text domain loading and WooCommerce initialization
- implement an email validator service that checks syntax, DNS, disposable domains, and risky addresses with customizable filters
- wire WooCommerce checkout, registration, and order hooks to block invalid emails and provide user suggestions, plus ship a readme overview

## Testing
- php -l wp-content/plugins/woo-validate/woo-validate.php
- php -l wp-content/plugins/woo-validate/includes/class-woo-validate-validator.php
- php -l wp-content/plugins/woo-validate/includes/class-woo-validate-checkout.php

------
https://chatgpt.com/codex/tasks/task_e_68cb6e5f327c832cbca083a063160884